### PR TITLE
ESXi auth additions

### DIFF
--- a/lib/virt.rb
+++ b/lib/virt.rb
@@ -9,8 +9,8 @@ module Virt
 
   class << self
 
-    def connect uri
-      @connection = Virt::Connection.new uri
+    def connect uri, options = {}
+      @connection = Virt::Connection.new uri,options
     end
 
     def connection

--- a/lib/virt/connection.rb
+++ b/lib/virt/connection.rb
@@ -5,7 +5,16 @@ module Virt
 
     def initialize uri
       raise("Must provide a guest to connect to") unless uri
-      @connection = Libvirt::open uri
+      @connection = Libvirt::open_auth(uri, [Libvirt::CRED_AUTHNAME, Libvirt::CRED_PASSPHRASE]) do |cred|
+        # This may only be required for ESXi connections, not sure.
+        if cred['type'] == ::Libvirt::CRED_AUTHNAME
+          res = SETTINGS[:esxi_username]
+        elsif cred["type"] == ::Libvirt::CRED_PASSPHRASE
+          res = SETTINGS[:esxi_password]
+        else
+          # cred type not supported
+        end
+      end
     end
 
     def closed?

--- a/lib/virt/connection.rb
+++ b/lib/virt/connection.rb
@@ -3,17 +3,21 @@ module Virt
   class Connection
     attr_reader :connection
 
-    def initialize uri
-      raise("Must provide a guest to connect to") unless uri
-      @connection = Libvirt::open_auth(uri, [Libvirt::CRED_AUTHNAME, Libvirt::CRED_PASSPHRASE]) do |cred|
-        # This may only be required for ESXi connections, not sure.
-        if cred['type'] == ::Libvirt::CRED_AUTHNAME
-          res = SETTINGS[:esxi_username]
-        elsif cred["type"] == ::Libvirt::CRED_PASSPHRASE
-          res = SETTINGS[:esxi_password]
-        else
-          # cred type not supported
+    def initialize uri, options = {}
+      raise("Must provide a host to connect to") unless uri 
+      if options[:password] != nil then 
+        @connection = Libvirt::open_auth(uri, [Libvirt::CRED_AUTHNAME, Libvirt::CRED_PASSPHRASE]) do |cred|
+          # This may only be required for ESXi connections, not sure.
+          if cred['type'] == ::Libvirt::CRED_AUTHNAME
+            res = options[:username]
+          elsif cred["type"] == ::Libvirt::CRED_PASSPHRASE
+            res = options[:password]
+          else
+            # cred type not supported
+          end
         end
+      else 
+        @connection = Libvirt::open uri
       end
     end
 

--- a/lib/virt/guest.rb
+++ b/lib/virt/guest.rb
@@ -1,7 +1,7 @@
 module Virt
   class Guest
     include Virt::Util
-    attr_reader :name, :xml_desc, :arch, :current_memory, :type, :boot_device, :machine
+    attr_reader :id, :name, :xml_desc, :arch, :current_memory, :type, :boot_device, :machine
     attr_accessor :memory, :vcpu, :volume, :interface, :template_path
 
     def initialize options = {}
@@ -10,6 +10,7 @@ module Virt
 
       # If our domain exists, we ignore the provided options and defaults
       fetch_guest
+      
       @memory ||= options[:memory] || default_memory_size
       @vcpu   ||= options[:vcpu]   || default_vcpu_count
       @arch   ||= options[:arch]   || default_arch
@@ -105,6 +106,7 @@ module Virt
       @memory         = @domain.max_memory
       @current_memory = document("domain/currentMemory") if running?
       @type           = document("domain", "type")
+      @id             = document("domain", "id")
       @vcpu           = document("domain/vcpu")
       @arch           = document("domain/os/type", "arch")
       @machine        = document("domain/os/type", "machine")

--- a/lib/virt/util.rb
+++ b/lib/virt/util.rb
@@ -20,7 +20,7 @@ module Virt
     def document path, attribute=nil
       return nil if new?
       xml = REXML::Document.new(@xml_desc)
-      attribute.nil? ? xml.elements[path].text : xml.elements[path].attributes[attribute]
+      xml.elements[path].nil? ? '' : (attribute.nil? ? xml.elements[path].text : xml.elements[path].attributes[attribute])
     end
   end
 end


### PR DESCRIPTION
Add settings to allow esxi auth parameters
Add handling for missing boot dev element in XML returned for ESXi server

These files go with the foreman additions.  I added two params for the foreman settings.yaml:
:esxi_username
:esxi_password

I am not very familiar with sasl, so I took a shortcut to getting connected to my esxi hosts.  Hopefully I figure out the sasl part, and these params can go away in favor of whatever libvirt supports.
